### PR TITLE
23 send reminder bugimprovement

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -49,7 +49,8 @@ if ($current_event == 'Yes') {
 	$current_event_characters = $api->get_characters_upcoming_event();
 }
 
-function hasId( $arr, $id ) {
+function hasId($arr, $id)
+{
 	foreach ($arr as $value) {
 		if ($value['characterID'] == $id) {
 			return true;
@@ -150,53 +151,45 @@ require './partials/email_messages.php';
 				if ($tab === 'concept') {
 					echo 'class="active"';
 				}
-				?>
-					onclick="window.location.href='?tab=concept&current_event=' . $current_event; ?>';">
+				?>>
 					Concept
 				</button>
 				<button data-tab="backstory" <?php
 				if ($tab === 'backstory') {
 					echo 'class="active"';
 				}
-				?>
-					onclick="window.location.href='?tab=backstory&current_event=' . $current_event; ?>';">
+				?>>
 					Backstory
 				</button>
 				<button data-tab="completed" <?php
 				if ($tab === 'completed') {
 					echo 'class="active"';
 				}
-				?>
-					onclick="window.location.href='?tab=completed&current_event=' . $current_event; ?>';">
+				?>>
 					Completed
 				</button>
 				<button data-tab="submit_existing" <?php
 				if ($tab === 'submit_existing') {
 					echo 'class="active"';
 				}
-				?>
-					onclick="window.location.href='?tab=submit_existing&current_event=' . $current_event; ?>';">
+				?>>
 					Submit Existing Backstory
 				</button>
 			</div>
 			<div class="tabs">
-				<div data-tab="concept" class="tab
-			<?php
-			if ($tab === 'concept') {
-				echo ' active';
-			}
-			?>
-			">
+				<div data-tab="concept" class="tab <?php if ($tab === 'concept') {
+					echo ' active';
+				} ?> ">
 					<h2>Concept</h2>
 					<?php require './partials/concepts.php'; ?>
 				</div>
 				<div data-tab="backstory" class="tab
-			<?php
-			if ($tab === 'backstory') {
-				echo ' active';
-			}
-			?>
-			">
+					<?php
+					if ($tab === 'backstory') {
+						echo ' active';
+					}
+					?>
+					">
 					<h2>Backstory</h2>
 					<?php require './partials/backstory.php'; ?>
 				</div>

--- a/admin/index.php
+++ b/admin/index.php
@@ -39,7 +39,6 @@ use Eos\Backstory_generator\Character\Character;
 use Eos\Backstory_generator\Text\Text;
 use Eos\Backstory_generator\Status\Status;
 use Eos\Backstory_generator\Api\Get;
-use Eos\Backstory_generator\Email\Send_Email;
 
 $character = new Character();
 $text = new Text();
@@ -61,175 +60,7 @@ function hasId( $arr, $id ) {
 //
 // messaging section
 //
-
-// Request Backstory Changes
-if (isset($_POST['backstory_changes'])) {
-
-	$email = $api->get_user_email($_POST['id']);
-
-	if ($email) {
-		$mail = new Send_Email();
-		if ($_POST['type'] == 'backstory_changes_remind') {
-			$subject = 'REMINDER: Backstory changes requested';
-			$body = "Dear player,
-		<br /><br />
-		This is a reminder that the SL team have requested a change in your character backstory. <br />
-		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
-		<br />
-		<br />
-		Kind regards,
-		<br />
-		The Spelleider Team<br />
-		Eos: Frontier";
-		} 
-			else {
-				$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
-				$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
-				$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
-				$subject = 'Backstory changes requested';
-				$body = "Dear player,
-				<br /><br />
-				The SL team have requested a change in your character backstory. <br />
-				Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
-				<br />
-				<br />
-				Kind regards,
-				<br />
-				The Spelleider Team<br />
-				Eos: Frontier";
-			}
-		$mail->send_email_to_player($email, $subject, $body);
-
-	}
-
-	unset($_POST['backstory_changes']);
-	unset($_POST['content']);
-	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
-}
-
-if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'approved')) {
-	$email = $api->get_user_email($_POST['id']);
-	if ($_POST['type'] == 'concept_remind') {
-		$mail = new Send_Email();
-		$subject = 'REMINDER: Character Concept approved - please submit backstory.';
-		$body = "Dear player,
-		<br /><br />
-		This is a reminder that the SL team have approved your character concept. <br />
-		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
-		<br /><br />
-		Kind regards,
-		<br />
-		The Spelleider Team<br />
-		Eos: Frontier";
-		$mail->send_email_to_player($email, $subject, $body);
-	} 
-	else {
-		if (isset($_POST['backstory-content']) && $_POST['type'] == 'backstory') {
-			$id = $_POST['id'];
-			$content['content'] = str_replace("'", '&#39;', $_POST['backstory-content']);
-			$text->save_backstory($id, $content, $jid);
-		}
-
-		if (isset($_POST['method']) && $_POST['method'] == 'sl_backend') {
-			$status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
-		} 
-		else {
-			$mail = new Send_Email();
-			if ($_POST['type'] == 'concept') {
-				$subject = 'Character Concept approved - please submit backstory.';
-				if (isset($_POST['concept_comment'])) {
-					$content['content'] = str_replace("'", '&#39;', $_POST['concept_comment']);
-					$return = $text->save_concept_comment($_POST['id'], $content);
-					$comment = $content['content'];
-					$body = "Dear player,	
-						<br /><br />
-						The SL team have approved your character concept. <br />
-						Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
-						<br />
-						The SL team have included the following comment: " . $content['content'] . "
-						<br />
-						Kind regards,
-						<br />
-						The Spelleider Team<br />
-						Eos: Frontier";
-				} 
-				else {
-					$body = "Dear player,
-					<br /><br />
-					The SL team have approved your character concept. <br />
-					Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
-					<br />
-					Kind regards,
-					<br />
-					The Spelleider Team<br />
-					Eos: Frontier";
-				}
-			}
-			if ($_POST['type'] == 'backstory') {
-				$subject = 'Character Backstory approved.';
-				$body = "Dear player,
-				<br /><br />
-				The SL team have approved your character backstory. You're all set! <br />
-				We look forward to welcoming your new character to Eos!		<br />
-				<br />
-				<br />
-				Kind regards,
-				<br />
-				The Spelleider Team<br />
-				Eos: Frontier";
-			}
-			$mail->send_email_to_player($email, $subject, $body);
-			$saved = $status->update_status($_POST['id'], $_POST['status'], $_POST['type'], $jid);
-		}
-	}
-	unset($_POST);
-	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
-}
-
-// Request concept changes
-if (isset($_POST['concept_changes'])) {
-	$email = $api->get_user_email($_POST['id']);
-	if ($email) {
-		$mail = new Send_Email();
-		if ($_POST['type'] == 'concept_changes_remind') {
-			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
-			$subject = 'REMINDER: Character Concept changes requested.';
-			$body = "Dear player,
-			<br /><br />
-			This is a reminder that the SL team have requested a change in your character concept. <br />
-			Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
-			<br />
-			<br />
-			Kind regards,
-			<br />
-			The Spelleider Team<br />
-			Eos: Frontier";
-			$mail->send_email_to_player($email, $subject, $body);
-		} 
-		else {
-			$content['content'] = str_replace("'", '&#39;', $_POST['concept_changes']);
-			$return = $text->save_concept_changes($_POST['id'], $content, $jid);
-			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
-			$subject = 'Character Concept changes requested.';
-			$body = "Dear player,
-			<br /><br />
-			The SL team have requested a change in your character concept. <br />
-			Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
-			<br />
-			<br />
-			Kind regards,
-			<br />
-			The Spelleider Team<br />
-			Eos: Frontier";
-			$mail->send_email_to_player($email, $subject, $body);
-		}
-	}
-
-	unset($_POST['concept_changes']);
-	unset($content);
-	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
-}
-
+require './partials/email_messages.php';
 //
 // End messaging section
 //
@@ -298,7 +129,7 @@ if (isset($_POST['concept_changes'])) {
 			<?php echo $jname; ?>!
 		</p>
 
-		<div class="formitem center-xs factionblurb fct_selector" style="display: none">
+		<div class="formitem center-xs overview-row fct_selector" style="display: none">
 			Filter by faction:</br>
 			<select name="factionselect" id="chooseFactionSelect" onchange="switchFactionBlurb(this.value);">
 				<option selected value="*">All Factions</option>

--- a/admin/partials/backstory.php
+++ b/admin/partials/backstory.php
@@ -96,8 +96,10 @@ if (!empty($being_edited)) {
 			?>
 		</div>
 	</div>
-	<hr />
 	<?php
+	if(!empty($backstory_changes)){
+		echo '<hr />';
+	}
 }
 
 if (!empty($backstory_changes)) {

--- a/admin/partials/backstory.php
+++ b/admin/partials/backstory.php
@@ -1,94 +1,120 @@
 <?php
 
-if ( isset( $_POST['type'] ) && $_POST['type'] === 'backstory' ) {
-	$status->update_status( $_POST['id'], $_POST['status'], $_POST['type'], $jid );
-	if ( $_POST['status'] === 'approved' ) {
-		$status->update_status( $_POST['id'], 'approved', 'backstory', $jid );
+if (isset($_POST['type']) && $_POST['type'] === 'backstory') {
+	$status->update_status($_POST['id'], $_POST['status'], $_POST['type'], $jid);
+	if ($_POST['status'] === 'approved') {
+		$status->update_status($_POST['id'], 'approved', 'backstory', $jid);
 	}
 }
 
 $backstorys = $text->get_all_backstory();
 
-$awaiting_review   = [];
-$being_edited      = [];
+$backstory_requested = [];
+$awaiting_review = [];
+$being_edited = [];
 $backstory_changes = [];
 
-foreach ( $backstorys as $backstory ) {
-	if ( $current_event === 'Yes' && ! hasId( $current_event_characters, $backstory->characterID ) ) {
+foreach ($backstorys as $backstory) {
+	if ($current_event === 'Yes' && !hasId($current_event_characters, $backstory->characterID)) {
 		continue;
 	}
-	if ( isset( $_GET['faction'] ) && $_GET['faction'] != '' && $backstory->faction != $_GET['faction'] ) {
+	if (isset($_GET['faction']) && $_GET['faction'] != '' && $backstory->faction != $_GET['faction']) {
 		continue;
 	} else {
-		if ( $backstory->backstory_status === 'requested' || $backstory->backstory_status === 'being_edited' ) {
-			$concept = $text->get_concept( $backstory->characterID );
-			if ( $concept->status_name == 'approved' ) {
-				$requested[] = $concept;
+		if ($backstory->backstory_status === 'requested') {
+			$concept = $text->get_concept($backstory->characterID);
+			if ($concept->status_name == 'approved') {
+				$backstory_requested[] = $concept;
 			}
 		}
 
-		if ( $backstory->backstory_status === 'being_edited' ) {
+		if ($backstory->backstory_status === 'being_edited') {
 			$being_edited[] = $backstory;
 		}
 
-		if ( $backstory->backstory_status === 'awaiting_review' ) {
+		if ($backstory->backstory_status === 'awaiting_review') {
 			$awaiting_review[] = $backstory;
 		}
 
-		if ( $backstory->backstory_status === 'changes_requested' ) {
+		if ($backstory->backstory_status === 'changes_requested') {
 			$backstory_changes[] = $backstory;
 		}
 	}
 }
 
-?>
-<h3>Requested</h3>
-<h5>These characters have an approved concept. They have been requested to provide a backstory submission.</br>
-	Here you can review their approved CONCEPT.</h5>
-<?php
-if ( ! empty( $requested ) ) {
-	$key_values = array_column( $requested, 'name' );
-	array_multisort( $key_values, SORT_ASC, $requested );
+if (!empty($requested)) {
+	?>
+	<div class="status-block">
+		<h3 class="mouse_hover">Requested (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<h5>These characters have an approved concept. They have been requested to provide a backstory submission.</br>
+				Here you can review their approved CONCEPT.</h5>
+			<?php
+			$key_values = array_column($requested, 'name');
+			array_multisort($key_values, SORT_ASC, $requested);
 
-	foreach ( $requested as $request ) {
-		include './partials/backstory_requested.php';
-	}
+			foreach ($backstory_requested as $request) {
+				include './partials/backstory_requested.php';
+			}
+			?>
+		</div>
+	</div>
+	<hr />
+	<?php
 }
-?>
-<hr/>
 
-<h3>Awaiting review</h3>
-<?php
-if ( ! empty( $awaiting_review ) ) {
-	$key_values = array_column( $awaiting_review, 'name' );
-	array_multisort( $key_values, SORT_ASC, $awaiting_review );
+if (!empty($awaiting_review)) {
+	?>
+	<div class="status-block">
+		<h3 class="mouse_hover">Awaiting review (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($awaiting_review, 'name');
+			array_multisort($key_values, SORT_ASC, $awaiting_review);
 
-	foreach ( $awaiting_review as $awaiting ) {
-		include './partials/backstory_review.php';
-	}
+			foreach ($awaiting_review as $awaiting) {
+				include './partials/backstory_review.php';
+			}
+			?>
+		</div>
+	</div>
+	<hr />
+	<?php
 }
-?>
-<hr/>
-<h3>Being edited</h3>
-<?php
-if ( ! empty( $being_edited ) ) {
-	$key_values = array_column( $being_edited, 'name' );
-	array_multisort( $key_values, SORT_ASC, $being_edited );
+if (!empty($being_edited)) {
+	?>
+	<div class="status-block">
+		<h3 class="mouse_hover">Being Edited (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($being_edited, 'name');
+			array_multisort($key_values, SORT_ASC, $being_edited);
 
-	foreach ( $being_edited as $edited ) {
-		include './partials/backstory_edited.php';
-	}
+			foreach ($being_edited as $edited) {
+				include './partials/backstory_edited.php';
+			}
+			?>
+		</div>
+	</div>
+	<hr />
+	<?php
 }
-?>
-<hr/>
-<h3>Backstory changes requested</h3>
-<?php
-if ( ! empty( $backstory_changes ) ) {
-	$key_values = array_column( $backstory_changes, 'name' );
-	array_multisort( $key_values, SORT_ASC, $backstory_changes );
 
-	foreach ( $backstory_changes as $edited ) {
-		include './partials/backstory_edited.php';
-	}
+if (!empty($backstory_changes)) {
+	?>
+	<div class="status-block">
+		<h3 class="mouse_hover">Backstory changes requested (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($backstory_changes, 'name');
+			array_multisort($key_values, SORT_ASC, $backstory_changes);
+
+			foreach ($backstory_changes as $edited) {
+				include './partials/backstory_edited.php';
+			}
+			?>
+		</div>
+	</div>
+	<?php
 }
 ?>

--- a/admin/partials/backstory.php
+++ b/admin/partials/backstory.php
@@ -7,14 +7,14 @@ if (isset($_POST['type']) && $_POST['type'] === 'backstory') {
 	}
 }
 
-$backstorys = $text->get_all_backstory();
+$backstories = $text->get_all_backstory();
 
 $backstory_requested = [];
 $awaiting_review = [];
 $being_edited = [];
 $backstory_changes = [];
 
-foreach ($backstorys as $backstory) {
+foreach ($backstories as $backstory) {
 	if ($current_event === 'Yes' && !hasId($current_event_characters, $backstory->characterID)) {
 		continue;
 	}
@@ -109,8 +109,8 @@ if (!empty($backstory_changes)) {
 			$key_values = array_column($backstory_changes, 'name');
 			array_multisort($key_values, SORT_ASC, $backstory_changes);
 
-			foreach ($backstory_changes as $edited) {
-				include './partials/backstory_edited.php';
+			foreach ($backstory_changes as $backstory_change) {
+				include './partials/backstory_change_requested.php';
 			}
 			?>
 		</div>

--- a/admin/partials/backstory.php
+++ b/admin/partials/backstory.php
@@ -42,7 +42,7 @@ foreach ($backstories as $backstory) {
 	}
 }
 
-if (!empty($requested)) {
+if (!empty($backstory_requested)) {
 	?>
 	<div class="status-block">
 		<h3 class="mouse_hover">Requested (click to expand)</h3>
@@ -50,8 +50,8 @@ if (!empty($requested)) {
 			<h5>These characters have an approved concept. They have been requested to provide a backstory submission.</br>
 				Here you can review their approved CONCEPT.</h5>
 			<?php
-			$key_values = array_column($requested, 'name');
-			array_multisort($key_values, SORT_ASC, $requested);
+			$key_values = array_column($backstory_requested, 'name');
+			array_multisort($key_values, SORT_ASC, $backstory_requested);
 
 			foreach ($backstory_requested as $request) {
 				include './partials/backstory_requested.php';

--- a/admin/partials/backstory_change_requested.php
+++ b/admin/partials/backstory_change_requested.php
@@ -4,15 +4,15 @@ use Eos\Backstory_generator\Text\Text;
 
 $text = new Text();
 ?>
-<div class="factionblurb fct_<?php echo $edited->faction; ?> overview-block" style="display: none;">
+<div class="factionblurb fct_<?php echo $backstory_change->faction; ?> overview-block" style="display: none;">
 	<h4 class="mouse_hover">
-		<?php echo $edited->name; ?> -
-		<?php echo $edited->faction; ?>
+		<?php echo $backstory_change->name; ?> -
+		<?php echo $backstory_change->faction; ?>
 	</h4>
 	<div class="admin_concept_edit">
 		<?php
-		echo '<h5>Date Last Updated: ' . $edited->backstory_updated_date . '</br>
-		Last Updated By: ' . $edited->backstory_updated_by . '</h5>';
+		echo '<h5>Date Last Updated: ' . $backstory_change->backstory_updated_date . '</br>
+		Last Updated By: ' . $backstory_change->backstory_updated_by . '</h5>';
 		if ($IS_SL) {
 			?>
 			<div class="overview-block">
@@ -20,30 +20,42 @@ $text = new Text();
 				<div class="admin_concept_edit">
 					<?php
 					echo '<div class="content-block">';
-					echo $edited->concept_content;
+					echo $backstory_change->concept_content;
 					echo '</div></div></div>';
 					echo '<h5>Backstory text</br>';
 					echo '<div class="content-block">';
-					echo $edited->content;
+					echo $backstory_change->content;
 					echo '</div>';
 		}
-		if ($edited->backstory_changes) {
-			echo '<h5>Date Backstory Changes Requested: ' . $edited->backstory_changes_requested_date . '</br>
-		Backstory Changes Requested By: ' . $edited->backstory_changes_requested_by . '</h5>';
+		if ($backstory_change->backstory_changes) {
+			echo '<h5>Date Backstory Changes Requested: ' . $backstory_change->backstory_changes_requested_date . '</br>
+		Backstory Changes Requested By: ' . $backstory_change->backstory_changes_requested_by . '</h5>';
 			if ($IS_SL) {
 				echo '<h5>Backstory changes</h5>
 				<div class="content-block">';
-				echo $edited->backstory_changes;
+				echo $backstory_change->backstory_changes;
 				echo '</div>';
 				?>
+						<h5> Last Reminder Sent:
+							<font <?php
+							$daysSinceReminder = time() - strtotime($backstory_change->last_reminder_sent);
+							if ($daysSinceReminder < 7 * 86400) {
+								echo 'color="red"';
+							}
+							echo ">";
+							echo $backstory_change->last_reminder_sent; ?> 		<?php if ($daysSinceReminder < 7 * 86400) {
+										   echo '(within last 7 days)';
+									   }
+									   ?> </font>
+						</h5>
 						<form name="concept_remind" method="POST" class="approve_form_concept"
-							id="concept-remind-<?php echo $edited->characterID; ?>">
+							id="concept-remind-<?php echo $backstory_change->characterID; ?>">
 							<input type="hidden" name="type" value="backstory_changes_remind" />
 							<input type="hidden" name="backstory_changes" value="true" />
-							<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
+							<input type="hidden" name="id" value="<?php echo $backstory_change->characterID; ?>" />
 							<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
 							<input type="hidden" name="status" value="approved" />
-							<button class="submit-backstory button button--primary">Send Reminder E-mail</button>
+							<button class="submit-backstory button button--primary">Remind Player to Make Backstory Changes</button>
 						</form>
 						<?php
 			}

--- a/admin/partials/backstory_change_requested.php
+++ b/admin/partials/backstory_change_requested.php
@@ -1,4 +1,4 @@
-<?php
+<b?php
 
 use Eos\Backstory_generator\Text\Text;
 
@@ -16,38 +16,54 @@ $text = new Text();
 		if ($IS_SL) {
 			?>
 			<div class="overview-block">
-				<h4 class="mouse_hover">Concept Text</h4>
+				<h4 class="mouse_hover">Concept</h4>
 				<div class="admin_concept_edit">
-					<?php
-					echo '<div class="content-block">';
-					echo $backstory_change->concept_content;
-					echo '</div></div></div>';
-					echo '<h5>Backstory text</br>';
-					echo '<div class="content-block">';
-					echo $backstory_change->content;
-					echo '</div>';
-		}
-		if ($backstory_change->backstory_changes) {
-			echo '<h5>Date Backstory Changes Requested: ' . $backstory_change->backstory_changes_requested_date . '</br>
-		Backstory Changes Requested By: ' . $backstory_change->backstory_changes_requested_by . '</h5>';
-			if ($IS_SL) {
-				echo '<h5>Backstory changes</h5>
-				<div class="content-block">';
-				echo $backstory_change->backstory_changes;
-				echo '</div>';
-				?>
-						<h5> Last Reminder Sent:
-							<font <?php
-							$daysSinceReminder = time() - strtotime($backstory_change->last_reminder_sent);
-							if ($daysSinceReminder < 7 * 86400) {
-								echo 'color="red"';
-							}
-							echo ">";
-							echo $backstory_change->last_reminder_sent; ?> 		<?php if ($daysSinceReminder < 7 * 86400) {
-										   echo '(within last 7 days)';
-									   }
-									   ?> </font>
-						</h5>
+					<h5 class="mouse_hover">Concept Text</h5>
+					<div class="admin_concept_edit">
+						<div class="content-block">
+							<?php echo $backstory_change->concept_content; ?>
+						</div>
+					</div>
+				</div>
+				<?php if (isset($backstory_change->concept_comment) && $backstory_change->concept_comment != '') { ?>
+				<h5 class="mouse_hover">Concept approval comment:</h5>
+				<div class="admin_concept_edit">
+					<div class="content-block">
+					<?php echo $backstory_change->concept_comment; ?>
+					</div>
+				</div>
+					<?php } ?>
+			<h4 class="mouse_hover">Backstory</h4>
+			<div class="admin_concept_edit">
+				<h5 class="mouse_hover">Backstory text</h5>
+					<div class="admin_concept_edit">
+						<div class="content-block">
+							<?php echo $backstory_change->content; ?>
+						</div>
+					</div>
+		<?php if ($backstory_change->backstory_changes) { ?>
+			<h5 class="mouse_hover">Backstory changes</h5>
+			<div class="admin_concept_edit">
+				<h6>Date Backstory Changes Requested: 
+					<?php echo $backstory_change->backstory_changes_requested_date; ?> </br>
+				Backstory Changes Requested By: <?php echo $backstory_change->backstory_changes_requested_by; ?> </h6>
+				<?php if ($IS_SL) { ?>
+					<div class="content-block">';
+					<?php echo $backstory_change->backstory_changes ?>
+					</div>
+				</div>
+					<?php } ?>
+					<h5> Last Reminder Sent:
+						<font <?php $daysSinceReminder = time() - strtotime($backstory_change->last_reminder_sent);
+						if ($daysSinceReminder < 7 * 86400) {
+							echo 'color="red"';
+						}
+						echo ">";
+						echo $backstory_change->last_reminder_sent; ?> 		<?php if ($daysSinceReminder < 7 * 86400) {
+										echo '(within last 7 days)';
+									}
+									?> </font> </br>
+					<?php if ($IS_SL) { ?>
 						<form name="concept_remind" method="POST" class="approve_form_concept"
 							id="concept-remind-<?php echo $backstory_change->characterID; ?>">
 							<input type="hidden" name="type" value="backstory_changes_remind" />
@@ -57,9 +73,11 @@ $text = new Text();
 							<input type="hidden" name="status" value="approved" />
 							<button class="submit-backstory button button--primary">Remind Player to Make Backstory Changes</button>
 						</form>
-						<?php
-			}
-		}
-		?>
-			</div>
+						</h5>
+						<?php } 
+			} 
+		}?>
 		</div>
+		</div>
+		</div>
+</div>

--- a/admin/partials/backstory_change_requested.php
+++ b/admin/partials/backstory_change_requested.php
@@ -80,4 +80,5 @@ $text = new Text();
 		</div>
 		</div>
 		</div>
+		</div>
 </div>

--- a/admin/partials/backstory_edited.php
+++ b/admin/partials/backstory_edited.php
@@ -16,17 +16,24 @@ $text = new Text();
 		if ($IS_SL) {
 			?>
 			<div class="overview-block">
-				<h4 class="mouse_hover">Concept Text</h4>
+			<h4 class="mouse_hover">Concept</h4>
 				<div class="admin_concept_edit">
-					<?php
-					echo '<div class="content-block">';
-					echo $edited->concept_content;
-					echo '</div></div></div>';
-					echo '<h5>Backstory text</br>';
-					echo '<div class="content-block">';
-					echo $edited->content;
-					echo '</div>';
-					?>
+					<h5 class="mouse_hover">Concept Text</h5>
+						<div class="admin_concept_edit">
+							<div class="content-block">';
+							<?php echo $edited->concept_content; ?>
+							</div>
+						</div>
+					<?php if (isset($edited->concept_comment) && $edited->concept_comment != '') { ?>
+					<h5 class="mouse_hover">Concept approval comment:</h5>
+					<div class="admin_concept_edit">
+						<div class="content-block">
+						<?php echo $edited->concept_comment; ?>
+						</div>
+					</div>
+				</div>
+				<?php } ?>
+				</div>
 					<h5> Last Reminder Sent:
 						<font <?php
 						$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);

--- a/admin/partials/backstory_edited.php
+++ b/admin/partials/backstory_edited.php
@@ -27,6 +27,18 @@ $text = new Text();
 					echo $edited->content;
 					echo '</div>';
 					?>
+					<h5> Last Reminder Sent:
+						<font <?php
+						$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);
+						if ($daysSinceReminder < 7 * 86400) {
+							echo 'color="red"';
+						}
+						echo ">";
+						echo $edited->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
+								   echo '(within last 7 days)';
+							   }
+							   ?> </font>
+					</h5>
 					<form name="concept_changes_remind" method="POST" class="approve_form_concept"
 						id="concept-changes-remind-<?php echo $edited->characterID; ?>">
 						<input type="hidden" name="type" value="backstory_not_submitted_remind" />

--- a/admin/partials/backstory_edited.php
+++ b/admin/partials/backstory_edited.php
@@ -33,6 +33,12 @@ $text = new Text();
 					</div>
 				</div>
 				<?php } ?>
+				<h4 class="mouse_hover">Backstory:</h4>
+				<div class="admin_concept_edit">
+					<div class="content-block">
+					<?php echo $edited->content; ?>
+					</div>
+				</div>
 				</div>
 					<h5> Last Reminder Sent:
 						<font <?php

--- a/admin/partials/backstory_edited.php
+++ b/admin/partials/backstory_edited.php
@@ -26,6 +26,18 @@ $text = new Text();
 					echo '<div class="content-block">';
 					echo $edited->content;
 					echo '</div>';
+					?>
+					<form name="concept_changes_remind" method="POST" class="approve_form_concept"
+						id="concept-changes-remind-<?php echo $edited->characterID; ?>">
+						<input type="hidden" name="type" value="backstory_not_submitted_remind" />
+						<input type="hidden" name="email_trigger" value="true" />
+						<input type="hidden" name="concept_changes" value="true" />
+						<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
+						<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
+						<input type="hidden" name="status" value="being_edited" />
+						<button class="submit-backstory button button--primary">Remind Player to Submit Backstory</button>
+					</form>
+					<?php
 		}
 		if ($edited->backstory_changes) {
 			echo '<h5>Date Backstory Changes Requested: ' . $edited->backstory_changes_requested_date . '</br>
@@ -35,17 +47,6 @@ $text = new Text();
 				<div class="content-block">';
 				echo $edited->backstory_changes;
 				echo '</div>';
-				?>
-						<!-- <form name="concept_remind" method="POST" class="approve_form_concept"
-							id="concept-remind-<?php echo $edited->characterID; ?>">
-							<input type="hidden" name="type" value="backstory_changes_remind" />
-							<input type="hidden" name="backstory_changes" value="true" />
-							<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
-							<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
-							<input type="hidden" name="status" value="approved" />
-							<button class="submit-backstory button button--primary">Send Reminder E-mail</button>
-						</form> -->
-						<?php
 			}
 		}
 		?>

--- a/admin/partials/backstory_edited.php
+++ b/admin/partials/backstory_edited.php
@@ -5,10 +5,7 @@ use Eos\Backstory_generator\Text\Text;
 $text = new Text();
 ?>
 <div class="factionblurb fct_<?php echo $edited->faction; ?> overview-block" style="display: none;">
-	<h4 class="mouse_hover">
-		<?php echo $edited->name; ?> -
-		<?php echo $edited->faction; ?>
-	</h4>
+	<h4 class="mouse_hover"><?php echo $edited->name; ?> - <?php echo $edited->faction; ?></h4>
 	<div class="admin_concept_edit">
 		<?php
 		echo '<h5>Date Last Updated: ' . $edited->backstory_updated_date . '</br>
@@ -16,64 +13,59 @@ $text = new Text();
 		if ($IS_SL) {
 			?>
 			<div class="overview-block">
-			<h4 class="mouse_hover">Concept</h4>
+				<h4 class="mouse_hover">Concept</h4>
 				<div class="admin_concept_edit">
 					<h5 class="mouse_hover">Concept Text</h5>
+					<div class="admin_concept_edit">
+						<div class="content-block"><?php echo $edited->concept_content; ?> </div>
+					</div>
+					<?php if (isset($edited->concept_comment) && $edited->concept_comment != '') { ?>
+						<h5 class="mouse_hover">Concept approval comment:</h5>
 						<div class="admin_concept_edit">
-							<div class="content-block">';
-							<?php echo $edited->concept_content; ?>
+							<div class="content-block">
+								<?php echo $edited->concept_comment; ?>
 							</div>
 						</div>
-					<?php if (isset($edited->concept_comment) && $edited->concept_comment != '') { ?>
-					<h5 class="mouse_hover">Concept approval comment:</h5>
-					<div class="admin_concept_edit">
-						<div class="content-block">
-						<?php echo $edited->concept_comment; ?>
-						</div>
 					</div>
-				</div>
 				<?php } ?>
 				<h4 class="mouse_hover">Backstory:</h4>
 				<div class="admin_concept_edit">
 					<div class="content-block">
-					<?php echo $edited->content; ?>
+						<?php echo $edited->content; ?>
 					</div>
 				</div>
-				</div>
-					<h5> Last Reminder Sent:
-						<font <?php
-						$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);
-						if ($daysSinceReminder < 7 * 86400) {
-							echo 'color="red"';
-						}
-						echo ">";
-						echo $edited->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
-								   echo '(within last 7 days)';
-							   }
-							   ?> </font>
-					</h5>
-					<form name="concept_changes_remind" method="POST" class="approve_form_concept"
-						id="concept-changes-remind-<?php echo $edited->characterID; ?>">
-						<input type="hidden" name="type" value="backstory_not_submitted_remind" />
-						<input type="hidden" name="email_trigger" value="true" />
-						<input type="hidden" name="concept_changes" value="true" />
-						<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
-						<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
-						<input type="hidden" name="status" value="being_edited" />
-						<button class="submit-backstory button button--primary">Remind Player to Submit Backstory</button>
-					</form>
-					<?php
-		}
-		if ($edited->backstory_changes) {
-			echo '<h5>Date Backstory Changes Requested: ' . $edited->backstory_changes_requested_date . '</br>
-		Backstory Changes Requested By: ' . $edited->backstory_changes_requested_by . '</h5>';
-			if ($IS_SL) {
-				echo '<h5>Backstory changes</h5>
-				<div class="content-block">';
-				echo $edited->backstory_changes;
-				echo '</div>';
-			}
-		}
-		?>
 			</div>
-		</div>
+			<h5> Last Reminder Sent:
+				<font <?php
+				$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);
+				if ($daysSinceReminder < 7 * 86400) {
+					echo 'color="red"';
+				}
+				echo ">";
+				echo $edited->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
+						   echo '(within last 7 days)';
+					   }
+					   ?> </font>
+			</h5>
+			<form name="concept_changes_remind" method="POST" class="approve_form_concept"
+				id="concept-changes-remind-<?php echo $edited->characterID; ?>">
+				<input type="hidden" name="type" value="backstory_not_submitted_remind" />
+				<input type="hidden" name="email_trigger" value="true" />
+				<input type="hidden" name="concept_changes" value="true" />
+				<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
+				<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
+				<input type="hidden" name="status" value="being_edited" />
+				<button class="submit-backstory button button--primary">Remind Player to Submit Backstory</button>
+			</form>
+			<?php
+		}
+		if ($edited->backstory_changes) { ?>
+			<h5>Date Backstory Changes Requested: <?php echo $edited->backstory_changes_requested_date; ?> </br>
+		Backstory Changes Requested By: <?php echo $edited->backstory_changes_requested_by;?> </h5>
+			<?php if ($IS_SL) {
+				echo '<h5>Backstory changes</h5>';?>
+				<div class="content-block"><?php echo $edited->backstory_changes; ?> </div>
+			<?php } 
+		} ?>
+	</div>
+</div>

--- a/admin/partials/backstory_requested.php
+++ b/admin/partials/backstory_requested.php
@@ -25,6 +25,18 @@ $text = new Text();
 				echo '</div>';
 			}
 			?>
+			<h5> Last Reminder Sent:
+				<font <?php
+				$daysSinceReminder = time() - strtotime($request->last_reminder_sent);
+				if ($daysSinceReminder < 7 * 86400) {
+					echo 'color="red"';
+				}
+				echo ">";
+				echo $request->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
+						   echo '(within last 7 days)';
+					   }
+					   ?> </font>
+			</h5>
 			<form name="concept_remind" method="POST" class="approve_form_concept"
 				id="concept-remind-<?php echo $request->characterID; ?>">
 				<input type="hidden" name="type" value="concept_approved_remind" />

--- a/admin/partials/backstory_requested.php
+++ b/admin/partials/backstory_requested.php
@@ -5,26 +5,26 @@ use Eos\Backstory_generator\Text\Text;
 $text = new Text();
 ?>
 <div class="factionblurb fct_<?php echo $request->faction; ?> overview-block" style="display: none;">
-	<h4 class="mouse_hover">
-		<?php echo $request->name; ?> -
-		<?php echo $request->faction; ?>
-	</h4>
+	<h4 class="mouse_hover"> <?php echo $request->name; ?> - <?php echo $request->faction; ?> </h4>
 	<div class="admin_concept_edit">
 		<h5> Date Approved: <?php echo $request->concept_approval_date; ?></br>
-			Concept Approved By: <?php echo $request->concept_approved_by; ?> </h5>
-		<?php
-		if ($IS_SL) {
-			echo '<h4>Approved Concept:</h4>
-			<div class="content-block">';
-			echo $request->content;
-			echo '</div>';
-			if (isset($request->concept_comment) && $request->concept_comment != '') {
-				echo '<h4>Concept approval comment:</h4>';
-				echo '<div class="content-block">';
-				echo $request->concept_comment;
-				echo '</div>';
-			}
-			?>
+			 Concept Approved By: <?php echo $request->concept_approved_by; ?> </h5>
+		<?php if ($IS_SL) { ?>
+			<h4 class="mouse_hover">Approved Concept:</h4>
+			<div class="admin_concept_edit">
+				<div class="content-block">
+				<?php echo $request->content; 
+				echo '<!--' . $request->characterID . '-->'; ?>
+				</div>
+			</div>
+			<?php if (isset($request->concept_comment) && $request->concept_comment != '') { ?>
+				<h4 class="mouse_hover">Concept approval comment:</h4>
+				<div class="admin_concept_edit">
+					<div class="content-block">
+					<?php echo $request->concept_comment; ?>
+					</div>
+				</div>
+			<?php } ?>
 			<h5> Last Reminder Sent:
 				<font <?php
 				$daysSinceReminder = time() - strtotime($request->last_reminder_sent);

--- a/admin/partials/backstory_requested.php
+++ b/admin/partials/backstory_requested.php
@@ -27,12 +27,12 @@ $text = new Text();
 			?>
 			<form name="concept_remind" method="POST" class="approve_form_concept"
 				id="concept-remind-<?php echo $request->characterID; ?>">
-				<input type="hidden" name="type" value="concept_remind" />
+				<input type="hidden" name="type" value="concept_approved_remind" />
 				<input type="hidden" name="email_trigger" value="true" />
 				<input type="hidden" name="id" value="<?php echo $request->characterID; ?>" />
 				<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
 				<input type="hidden" name="status" value="approved" />
-				<button class="submit-backstory button button--primary">Send Reminder E-mail</button>
+				<button class="submit-backstory button button--primary">Remind Player to Submit Backstory</button>
 			</form>
 			<?php
 		}

--- a/admin/partials/backstory_requested.php
+++ b/admin/partials/backstory_requested.php
@@ -9,12 +9,13 @@ $text = new Text();
 	<div class="admin_concept_edit">
 		<h5> Date Approved: <?php echo $request->concept_approval_date; ?></br>
 			 Concept Approved By: <?php echo $request->concept_approved_by; ?> </h5>
-		<?php if ($IS_SL) { ?>
+		<?php if ($IS_SL) { 
+			echo '<!-- CharID for ' .  $request->name . ':' . $request->characterID . '-->'; ?>
 			<h4 class="mouse_hover">Approved Concept:</h4>
 			<div class="admin_concept_edit">
 				<div class="content-block">
-				<?php echo $request->content; 
-				echo '<!--' . $request->characterID . '-->'; ?>
+				<?php echo $request->content; ?>
+				
 				</div>
 			</div>
 			<?php if (isset($request->concept_comment) && $request->concept_comment != '') { ?>
@@ -49,5 +50,6 @@ $text = new Text();
 			<?php
 		}
 		?>
+		potato
 	</div>
 </div>

--- a/admin/partials/backstory_requested.php
+++ b/admin/partials/backstory_requested.php
@@ -50,6 +50,5 @@ $text = new Text();
 			<?php
 		}
 		?>
-		potato
 	</div>
 </div>

--- a/admin/partials/backstory_review.php
+++ b/admin/partials/backstory_review.php
@@ -16,18 +16,31 @@ $text = new Text();
 		if ($IS_SL) {
 			?>
 			<div class="overview-block">
-				<h4 class="mouse_hover">Concept Text</h4>
+				<h4 class="mouse_hover">Concept</h4>
 				<div class="admin_concept_edit">
-					<?php
-					echo '<div class="content-block">';
-					echo $awaiting->concept_content;
-					echo '</div></div></div>';
-					echo '<h4>Backstory Text</h4>';
-					echo '<div class="content-block">';
-					echo $awaiting->content;
-					echo '</div>';
-		}
-		?>
+				<h5 class="mouse_hover">Concept Text</h5>
+					<div class="admin_concept_edit">
+						<div class="content-block">';
+						<?php echo $awaiting->concept_content; ?>
+						</div>
+					</div>
+				<?php if (isset($awaiting->concept_comment) && $awaiting->concept_comment != '') { ?>
+				<h5 class="mouse_hover">Concept approval comment:</h5>
+				<div class="admin_concept_edit">
+					<div class="content-block">
+					<?php echo $awaiting->concept_comment; ?>
+					</div>
+				</div>
+				<?php } ?>
+				</div>
+				<h4 class="mouse_hover">Backstory Text</h4>
+				<div class="admin_concept_edit">
+					<div class="content-block">
+						<?php echo $awaiting->content; ?>
+					</div>
+				</div>
+			</div>
+		<?php } ?>
 				<div>
 					<?php if ($IS_SL) { ?>
 						<button class="concept_change-request-button button button--secondary"

--- a/admin/partials/concept_change_requested.php
+++ b/admin/partials/concept_change_requested.php
@@ -33,7 +33,7 @@ $text = new Text();
 					<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
 					<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
 					<input type="hidden" name="status" value="changes_requested" />
-					<button class="submit-backstory button button--primary">Send Reminder E-mail</button>
+					<button class="submit-backstory button button--primary">Remind Player to Make Concept Changes</button>
 				</form>
 				<?php
 			}

--- a/admin/partials/concept_change_requested.php
+++ b/admin/partials/concept_change_requested.php
@@ -25,6 +25,18 @@ $text = new Text();
 				echo '<h5>Concept changes</br>';
 				echo $edited->concept_changes;
 				?>
+				<h5> Last Reminder Sent:
+				<font <?php
+				$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);
+				if ($daysSinceReminder < 7 * 86400) {
+					echo 'color="red"';
+				}
+				echo ">";
+				echo $edited->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
+						   echo '(within last 7 days)';
+					   }
+					   ?> </font>
+			</h5>
 				<form name="concept_changes_remind" method="POST" class="approve_form_concept"
 					id="concept-changes-remind-<?php echo $edited->characterID; ?>">
 					<input type="hidden" name="type" value="concept_changes_remind" />

--- a/admin/partials/concept_change_requested.php
+++ b/admin/partials/concept_change_requested.php
@@ -22,7 +22,7 @@ $text = new Text();
 			echo '<h5>Date Concept Changes Requested: ' . $edited->concept_changes_requested_date . '</br>
 				Concept Changes Requested By: ' . $edited->concept_changes_requested_by . '</h5>';
 			if ($IS_SL) {
-				echo '<h5>Concept changes</br>';
+				echo '<h5>Concept changes</h5>';
 				echo $edited->concept_changes;
 				?>
 				<h5> Last Reminder Sent:

--- a/admin/partials/concept_edited.php
+++ b/admin/partials/concept_edited.php
@@ -17,6 +17,18 @@ $text = new Text();
 			echo '<div class="content-block">';
 			echo $edited->content;
 			echo '</div>';
+			?>
+			<form name="concept_changes_remind" method="POST" class="approve_form_concept"
+					id="concept-changes-remind-<?php echo $edited->characterID; ?>">
+					<input type="hidden" name="type" value="concept_not_submitted_remind" />
+					<input type="hidden" name="email_trigger" value="true" />
+					<input type="hidden" name="concept_changes" value="true" />
+					<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
+					<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
+					<input type="hidden" name="status" value="being_edited" />
+					<button class="submit-backstory button button--primary">Remind Player to Submit Concept</button>
+				</form>
+			<?php
 		}
 		if ($edited->concept_changes) {
 			echo '<h5>Date Concept Changes Requested: ' . $edited->concept_changes_requested_date . '</br>
@@ -24,18 +36,6 @@ $text = new Text();
 			if ($IS_SL) {
 				echo '<h5>Concept changes</br>';
 				echo $edited->concept_changes;
-				?>
-				<!-- <form name="concept_changes_remind" method="POST" class="approve_form_concept"
-					id="concept-changes-remind-<?php echo $edited->characterID; ?>">
-					<input type="hidden" name="type" value="concept_changes_remind" />
-					<input type="hidden" name="email_trigger" value="true" />
-					<input type="hidden" name="concept_changes" value="true" />
-					<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
-					<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
-					<input type="hidden" name="status" value="changes_requested" />
-					<button class="submit-backstory button button--primary">Send Reminder E-mail</button>
-				</form> -->
-				<?php
 			}
 		}
 

--- a/admin/partials/concept_edited.php
+++ b/admin/partials/concept_edited.php
@@ -18,16 +18,28 @@ $text = new Text();
 			echo $edited->content;
 			echo '</div>';
 			?>
+			<h5> Last Reminder Sent:
+				<font <?php
+				$daysSinceReminder = time() - strtotime($edited->last_reminder_sent);
+				if ($daysSinceReminder < 7 * 86400) {
+					echo 'color="red"';
+				}
+				echo ">";
+				echo $edited->last_reminder_sent; ?> 	<?php if ($daysSinceReminder < 7 * 86400) {
+						   echo '(within last 7 days)';
+					   }
+					   ?> </font>
+			</h5>
 			<form name="concept_changes_remind" method="POST" class="approve_form_concept"
-					id="concept-changes-remind-<?php echo $edited->characterID; ?>">
-					<input type="hidden" name="type" value="concept_not_submitted_remind" />
-					<input type="hidden" name="email_trigger" value="true" />
-					<input type="hidden" name="concept_changes" value="true" />
-					<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
-					<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
-					<input type="hidden" name="status" value="being_edited" />
-					<button class="submit-backstory button button--primary">Remind Player to Submit Concept</button>
-				</form>
+				id="concept-changes-remind-<?php echo $edited->characterID; ?>">
+				<input type="hidden" name="type" value="concept_not_submitted_remind" />
+				<input type="hidden" name="email_trigger" value="true" />
+				<input type="hidden" name="concept_changes" value="true" />
+				<input type="hidden" name="id" value="<?php echo $edited->characterID; ?>" />
+				<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
+				<input type="hidden" name="status" value="being_edited" />
+				<button class="submit-backstory button button--primary">Remind Player to Submit Concept</button>
+			</form>
 			<?php
 		}
 		if ($edited->concept_changes) {

--- a/admin/partials/concept_requested.php
+++ b/admin/partials/concept_requested.php
@@ -10,8 +10,20 @@ $text = new Text();
 		<?php echo $empty_concept->faction; ?>
 	</h4>
 	<div class="admin_concept_edit">
-		<!-- <h5> Date Concept Updated: <?php echo $empty_concept->concept_updated_date; ?></br>
-			Updated By: <?php echo $empty_concept->concept_updated_by; ?> </h5> -->
+		<h5> Last Reminder Sent: 
+			<font <?php 
+		$daysSinceReminder = time() - strtotime($empty_concept->last_reminder_sent);
+		if ($daysSinceReminder < 7*86400){
+			echo 'color="red"';
+		}
+		echo ">";
+		echo $empty_concept->last_reminder_sent; ?>
+		<?php if ($daysSinceReminder < 7*86400){
+			echo '(within last 7 days)';
+		}
+		?>
+		</font></br></h5> 
+			<!-- Updated By: <?php echo $empty_concept->concept_updated_by; ?> -->
 		<?php
 		if ($IS_SL) {
 			?>

--- a/admin/partials/concept_requested.php
+++ b/admin/partials/concept_requested.php
@@ -1,0 +1,41 @@
+<?php
+
+use Eos\Backstory_generator\Text\Text;
+
+$text = new Text();
+?>
+<div class="factionblurb fct_<?php echo $empty_concept->faction; ?> overview-block" style="display: none;">
+	<h4 class="mouse_hover">
+		<?php echo $empty_concept->name; ?> -
+		<?php echo $empty_concept->faction; ?>
+	</h4>
+	<div class="admin_concept_edit">
+		<!-- <h5> Date Concept Updated: <?php echo $empty_concept->concept_updated_date; ?></br>
+			Updated By: <?php echo $empty_concept->concept_updated_by; ?> </h5> -->
+		<?php
+		if ($IS_SL) {
+			?>
+			<form name="concept_changes_remind" method="POST" class="approve_form_concept"
+					id="concept-changes-remind-<?php echo $empty_concept->characterID; ?>">
+					<input type="hidden" name="type" value="concept_not_started_remind" />
+					<input type="hidden" name="email_trigger" value="true" />
+					<input type="hidden" name="concept_changes" value="true" />
+					<input type="hidden" name="id" value="<?php echo $empty_concept->characterID; ?>" />
+					<input type="hidden" name="tab" value="<?php echo $tab; ?>" />
+					<input type="hidden" name="status" value="requested" />
+					<button class="submit-backstory button button--primary">Remind Player to Submit Concept</button>
+				</form>
+			<?php
+		}
+		if ($empty_concept->concept_changes) {
+			echo '<h5>Date Concept Changes Requested: ' . $empty_concept->concept_changes_requested_date . '</br>
+				Concept Changes Requested By: ' . $empty_concept->concept_changes_requested_by . '</h5>';
+			if ($IS_SL) {
+				echo '<h5>Concept changes</br>';
+				echo $empty_concept->concept_changes;
+			}
+		}
+
+		?>
+	</div>
+</div>

--- a/admin/partials/concepts.php
+++ b/admin/partials/concepts.php
@@ -38,53 +38,74 @@ foreach ($concepts as $concept) {
 
 if (!empty($requested)) {
 	?>
-	<h3>Requested</h3>
-	<h4>These players have not started editing their concept first draft.</h4>
-		<?php
-		$key_values = array_column($requested, 'name');
-		array_multisort($key_values, SORT_ASC, $requested);
+	<div class="status-block">
+		<h3 class="mouse_hover">Requested (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($requested, 'name');
+			array_multisort($key_values, SORT_ASC, $requested);
 
-		foreach ($requested as $empty_concept) {
-			include './partials/concept_requested.php';
-		}
-		?>
+			foreach ($requested as $empty_concept) {
+				include './partials/concept_requested.php';
+			}
+			?>
+		</div>
+	</div>
 	<hr />
 	<?php
 }
 
 if (!empty($awaiting_review)) {
 	?>
-	<h3 class="mouse_hover">Awaiting review</h3>
-	<?php
-	$key_values = array_column($awaiting_review, 'name');
-	array_multisort($key_values, SORT_ASC, $awaiting_review);
+	<div class="status-block">
+		<h3 class="mouse_hover">Awaiting review (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($awaiting_review, 'name');
+			array_multisort($key_values, SORT_ASC, $awaiting_review);
 
-	foreach ($awaiting_review as $awaiting) {
-		include './partials/concept_review.php';
-	}
-	echo '<hr />';
+			foreach ($awaiting_review as $awaiting) {
+				include './partials/concept_review.php';
+			}
+			?>
+		</div>
+	</div>
+	<hr />
+	<?php
 }
 if (!empty($being_edited)) {
 	?>
-	<h3>Being edited</h3>
-	<?php
-	$key_values = array_column($being_edited, 'name');
-	array_multisort($key_values, SORT_ASC, $being_edited);
+	<div class="status-block">
+		<h3 class="mouse_hover">Being edited (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($being_edited, 'name');
+			array_multisort($key_values, SORT_ASC, $being_edited);
 
-	foreach ($being_edited as $edited) {
-		include './partials/concept_edited.php';
-	}
-	echo '<hr />';
+			foreach ($being_edited as $edited) {
+				include './partials/concept_edited.php';
+			}
+			?>
+		</div>
+	</div>
+	<hr />
+	<?php
 }
 
 if (!empty($concept_changes)) {
 	?>
-	<h3>Concept changes requested</h3>
-	<?php
-	$key_values = array_column($concept_changes, 'name');
-	array_multisort($key_values, SORT_ASC, $concept_changes);
+	<div class="status-block">
+		<h3 class="mouse_hover">Concept changes requested (click to expand)</h3>
+		<div class="admin_concept_edit">
+			<?php
+			$key_values = array_column($concept_changes, 'name');
+			array_multisort($key_values, SORT_ASC, $concept_changes);
 
-	foreach ($concept_changes as $edited) {
-		include './partials/concept_change_requested.php';
-	}
+			foreach ($concept_changes as $edited) {
+				include './partials/concept_change_requested.php';
+			}
+			?>
+		</div>
+	</div>
+	<?php
 }

--- a/admin/partials/concepts.php
+++ b/admin/partials/concepts.php
@@ -19,6 +19,9 @@ foreach ($concepts as $concept) {
 	if (isset($_GET['faction']) && $_GET['faction'] != '' && $concept->faction != $_GET['faction']) {
 		continue;
 	} else {
+		if ($concept->status_name === 'requested') {
+			$requested[] = $concept;
+		}
 		if ($concept->status_name === 'being_edited') {
 			$being_edited[] = $concept;
 		}
@@ -33,34 +36,51 @@ foreach ($concepts as $concept) {
 	}
 }
 
-?>
-<h3>Awaiting review</h3>
-<?php
+if (!empty($requested)) {
+	?>
+	<h3>Requested</h3>
+	<h4>These players have not started editing their concept first draft.</h4>
+		<?php
+		$key_values = array_column($requested, 'name');
+		array_multisort($key_values, SORT_ASC, $requested);
+
+		foreach ($requested as $empty_concept) {
+			include './partials/concept_requested.php';
+		}
+		?>
+	<hr />
+	<?php
+}
+
 if (!empty($awaiting_review)) {
+	?>
+	<h3 class="mouse_hover">Awaiting review</h3>
+	<?php
 	$key_values = array_column($awaiting_review, 'name');
 	array_multisort($key_values, SORT_ASC, $awaiting_review);
 
 	foreach ($awaiting_review as $awaiting) {
 		include './partials/concept_review.php';
 	}
+	echo '<hr />';
 }
-?>
-<hr />
-<h3>Being edited</h3>
-<?php
 if (!empty($being_edited)) {
+	?>
+	<h3>Being edited</h3>
+	<?php
 	$key_values = array_column($being_edited, 'name');
 	array_multisort($key_values, SORT_ASC, $being_edited);
 
 	foreach ($being_edited as $edited) {
 		include './partials/concept_edited.php';
 	}
+	echo '<hr />';
 }
-?>
-<hr />
-<h3>Concept changes requested</h3>
-<?php
+
 if (!empty($concept_changes)) {
+	?>
+	<h3>Concept changes requested</h3>
+	<?php
 	$key_values = array_column($concept_changes, 'name');
 	array_multisort($key_values, SORT_ASC, $concept_changes);
 
@@ -68,4 +88,3 @@ if (!empty($concept_changes)) {
 		include './partials/concept_change_requested.php';
 	}
 }
-?>

--- a/admin/partials/concepts.php
+++ b/admin/partials/concepts.php
@@ -88,12 +88,12 @@ if (!empty($being_edited)) {
 			?>
 		</div>
 	</div>
-	<hr />
 	<?php
 }
 
 if (!empty($concept_changes)) {
 	?>
+	<hr />
 	<div class="status-block">
 		<h3 class="mouse_hover">Concept changes requested (click to expand)</h3>
 		<div class="admin_concept_edit">

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -1,5 +1,7 @@
 <?php
 use Eos\Backstory_generator\Email\Send_Email;
+use Eos\Backstory_generator\Api\Put;
+$apiPut = new Put();
 
 // Request Backstory Changes
 if (isset($_POST['backstory_changes'])) {
@@ -20,12 +22,13 @@ if (isset($_POST['backstory_changes'])) {
 		<br />
 		The Spelleider Team<br />
 		Eos: Frontier";
-		} else {
-			$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
-			$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
-			$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
-			$subject = 'Backstory changes requested';
-			$body = "Dear player,
+		} 
+			else {
+				$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
+				$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
+				$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
+				$subject = 'Backstory changes requested';
+				$body = "Dear player,
 				<br /><br />
 				The SL team have requested a change in your character backstory. <br />
 				Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
@@ -35,7 +38,7 @@ if (isset($_POST['backstory_changes'])) {
 				<br />
 				The Spelleider Team<br />
 				Eos: Frontier";
-		}
+			}
 		$mail->send_email_to_player($email, $subject, $body);
 
 	}
@@ -47,8 +50,8 @@ if (isset($_POST['backstory_changes'])) {
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'approved')) {
 	$email = $api->get_user_email($_POST['id']);
-	//Reminder that concept is approved, backstory is not started
-	if ($_POST['type'] == 'concept_approved_remind') {
+    //Reminder that concept is approved, backstory is not started
+    if ($_POST['type'] == 'concept_approved_remind') {
 		$mail = new Send_Email();
 		$subject = 'REMINDER: Character Concept approved - please submit backstory.';
 		$body = "Dear player,
@@ -61,7 +64,8 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-	} else {
+	} 
+	else {
 		if (isset($_POST['backstory-content']) && $_POST['type'] == 'backstory') {
 			$id = $_POST['id'];
 			$content['content'] = str_replace("'", '&#39;', $_POST['backstory-content']);
@@ -71,7 +75,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		if (isset($_POST['method']) && $_POST['method'] == 'sl_backend') {
 			$status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
 		}
-		//Concept approved by SL - Notify player to work on their backstory 
+        //Concept approved by SL - Notify player to work on their backstory 
 		else {
 			$mail = new Send_Email();
 			if ($_POST['type'] == 'concept') {
@@ -91,7 +95,8 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 						<br />
 						The Spelleider Team<br />
 						Eos: Frontier";
-				} else {
+				} 
+				else {
 					$body = "Dear player,
 					<br /><br />
 					The SL team have approved your character concept. <br />
@@ -143,7 +148,9 @@ if (isset($_POST['concept_changes'])) {
 			The Spelleider Team<br />
 			Eos: Frontier";
 			$mail->send_email_to_player($email, $subject, $body);
-		} else {
+			$apiPut->set_reminder_time($_POST['id']);
+		} 
+		elseif ($_POST['type'] == 'changes_requested') {
 			$content['content'] = str_replace("'", '&#39;', $_POST['concept_changes']);
 			$return = $text->save_concept_changes($_POST['id'], $content, $jid);
 			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
@@ -171,8 +178,8 @@ if (isset($_POST['concept_changes'])) {
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'being_edited')) {
 	$email = $api->get_user_email($_POST['id']);
-	//Reminder that concept is approved, backstory is not started
-	if ($_POST['type'] == 'concept_not_submitted_remind') {
+    //Reminder that concept is approved, backstory is not started
+    if ($_POST['type'] == 'concept_not_submitted_remind') {
 		$mail = new Send_Email();
 		$subject = 'REMINDER: Character Concept not yet submitted.';
 		$body = "Dear player,
@@ -185,8 +192,10 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'be
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-	} elseif ($_POST['type'] == 'backstory_not_submitted_remind') {
-		$mail = new Send_Email();
+		$apiPut->set_reminder_time($_POST['id']);
+	} 
+    elseif ($_POST['type'] == 'backstory_not_submitted_remind') {
+        $mail = new Send_Email();
 		$subject = 'REMINDER: Backstory not yet submitted.';
 		$body = "Dear player,
 		<br /><br />
@@ -198,14 +207,15 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'be
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-	}
+		$apiPut->set_reminder_time($_POST['id']);
+    }
 }
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'requested')) {
-	if ($_POST['type'] == 'concept_not_started_remind') {
-		$mail = new Send_Email();
-		$subject = 'REMINDER: Concept not yet submitted.';
-		$body = "Dear player,
+    if ($_POST['type'] == 'concept_not_started_remind') {
+        $mail = new Send_Email();
+        $subject = 'REMINDER: Concept not yet submitted.';
+        $body = "Dear player,
         <br /><br />
         The SL team would like to remind you that we still need a Character Concept submitted. <br />
         Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your Character Concept for approval.
@@ -214,6 +224,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 're
         <br />
         The Spelleider Team<br />
         Eos: Frontier";
-		$mail->send_email_to_player($email, $subject, $body);
-	}
+        $mail->send_email_to_player($email, $subject, $body);
+		$apiPut->set_reminder_time($_POST['id']);
+    }
 }

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -1,0 +1,224 @@
+<?php
+use Eos\Backstory_generator\Email\Send_Email;
+
+// Request Backstory Changes
+if (isset($_POST['backstory_changes'])) {
+
+	$email = $api->get_user_email($_POST['id']);
+
+	if ($email) {
+		$mail = new Send_Email();
+		if ($_POST['type'] == 'backstory_changes_remind') {
+			$subject = 'REMINDER: Backstory changes requested';
+			$body = "Dear player,
+		<br /><br />
+		This is a reminder that the SL team have requested a change in your character backstory. <br />
+		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
+		<br />
+		<br />
+		Kind regards,
+		<br />
+		The Spelleider Team<br />
+		Eos: Frontier";
+		} 
+			else {
+				$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
+				$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
+				$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
+				$subject = 'Backstory changes requested';
+				$body = "Dear player,
+				<br /><br />
+				The SL team have requested a change in your character backstory. <br />
+				Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
+				<br />
+				<br />
+				Kind regards,
+				<br />
+				The Spelleider Team<br />
+				Eos: Frontier";
+			}
+		$mail->send_email_to_player($email, $subject, $body);
+
+	}
+
+	unset($_POST['backstory_changes']);
+	unset($_POST['content']);
+	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
+}
+
+if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'approved')) {
+	$email = $api->get_user_email($_POST['id']);
+    //Reminder that concept is approved, backstory is not started
+    if ($_POST['type'] == 'concept_approved_remind') {
+		$mail = new Send_Email();
+		$subject = 'REMINDER: Character Concept approved - please submit backstory.';
+		$body = "Dear player,
+		<br /><br />
+		This is a reminder that the SL team have approved your character concept. <br />
+		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
+		<br /><br />
+		Kind regards,
+		<br />
+		The Spelleider Team<br />
+		Eos: Frontier";
+		$mail->send_email_to_player($email, $subject, $body);
+	} 
+	else {
+		if (isset($_POST['backstory-content']) && $_POST['type'] == 'backstory') {
+			$id = $_POST['id'];
+			$content['content'] = str_replace("'", '&#39;', $_POST['backstory-content']);
+			$text->save_backstory($id, $content, $jid);
+		}
+
+		if (isset($_POST['method']) && $_POST['method'] == 'sl_backend') {
+			$status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
+		}
+        //Concept approved by SL - Notify player to work on their backstory 
+		else {
+			$mail = new Send_Email();
+			if ($_POST['type'] == 'concept') {
+				$subject = 'Character Concept approved - please submit backstory.';
+				if (isset($_POST['concept_comment'])) {
+					$content['content'] = str_replace("'", '&#39;', $_POST['concept_comment']);
+					$return = $text->save_concept_comment($_POST['id'], $content);
+					$comment = $content['content'];
+					$body = "Dear player,	
+						<br /><br />
+						The SL team have approved your character concept. <br />
+						Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
+						<br />
+						The SL team have included the following comment: " . $content['content'] . "
+						<br />
+						Kind regards,
+						<br />
+						The Spelleider Team<br />
+						Eos: Frontier";
+				} 
+				else {
+					$body = "Dear player,
+					<br /><br />
+					The SL team have approved your character concept. <br />
+					Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your full character backstory.
+					<br />
+					Kind regards,
+					<br />
+					The Spelleider Team<br />
+					Eos: Frontier";
+				}
+			}
+			if ($_POST['type'] == 'backstory') {
+				$subject = 'Character Backstory approved.';
+				$body = "Dear player,
+				<br /><br />
+				The SL team have approved your character backstory. You're all set! <br />
+				We look forward to welcoming your new character to Eos!		<br />
+				<br />
+				<br />
+				Kind regards,
+				<br />
+				The Spelleider Team<br />
+				Eos: Frontier";
+			}
+			$mail->send_email_to_player($email, $subject, $body);
+			$saved = $status->update_status($_POST['id'], $_POST['status'], $_POST['type'], $jid);
+		}
+	}
+	unset($_POST);
+	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
+}
+
+// Request concept changes
+if (isset($_POST['concept_changes'])) {
+	$email = $api->get_user_email($_POST['id']);
+	if ($email) {
+		$mail = new Send_Email();
+		if ($_POST['type'] == 'concept_changes_remind') {
+			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
+			$subject = 'REMINDER: Character Concept changes requested.';
+			$body = "Dear player,
+			<br /><br />
+			This is a reminder that the SL team have requested a change in your character concept. <br />
+			Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
+			<br />
+			<br />
+			Kind regards,
+			<br />
+			The Spelleider Team<br />
+			Eos: Frontier";
+			$mail->send_email_to_player($email, $subject, $body);
+		} 
+		else {
+			$content['content'] = str_replace("'", '&#39;', $_POST['concept_changes']);
+			$return = $text->save_concept_changes($_POST['id'], $content, $jid);
+			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
+			$subject = 'Character Concept changes requested.';
+			$body = "Dear player,
+			<br /><br />
+			The SL team have requested a change in your character concept. <br />
+			Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
+			<br />
+			<br />
+			Kind regards,
+			<br />
+			The Spelleider Team<br />
+			Eos: Frontier";
+			$mail->send_email_to_player($email, $subject, $body);
+		}
+	}
+
+	unset($_POST['concept_changes']);
+	unset($content);
+	header('Location: ./?tab=' . $tab . '&current_event=' . $current_event);
+}
+
+// Remind concept or backstory stuck in editing status
+
+if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'being_edited')) {
+	$email = $api->get_user_email($_POST['id']);
+    //Reminder that concept is approved, backstory is not started
+    if ($_POST['type'] == 'concept_not_submitted_remind') {
+		$mail = new Send_Email();
+		$subject = 'REMINDER: Character Concept not yet submitted.';
+		$body = "Dear player,
+		<br /><br />
+		The SL team would like to remind you that your Character Concept has been in the 'Being edited' status for an extended period of time. <br />
+		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to finish editing your concept and/or submit it to the SLs for approval.
+		<br /><br />
+		Kind regards,
+		<br />
+		The Spelleider Team<br />
+		Eos: Frontier";
+		$mail->send_email_to_player($email, $subject, $body);
+	} 
+    elseif ($_POST['type'] == 'backstory_not_submitted_remind') {
+        $mail = new Send_Email();
+		$subject = 'REMINDER: Backstory not yet submitted.';
+		$body = "Dear player,
+		<br /><br />
+		The SL team would like to remind you that your Backstory has been in the 'Being edited' status for an extended period of time. <br />
+		Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to finish editing your backstory and/or submit it to the SLs for approval.
+		<br /><br />
+		Kind regards,
+		<br />
+		The Spelleider Team<br />
+		Eos: Frontier";
+		$mail->send_email_to_player($email, $subject, $body);
+    }
+}
+
+if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'requested')) {
+    if ($_POST['type'] == 'concept_not_started_remind') {
+        $mail = new Send_Email();
+        $subject = 'REMINDER: Concept not yet submitted.';
+        $body = "Dear player,
+        <br /><br />
+        The SL team would like to remind you that we still need a Character Concept submitted.. <br />
+        Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your Character Concept for approval.
+        <br /><br />
+        Kind regards,
+        <br />
+        The Spelleider Team<br />
+        Eos: Frontier";
+        $mail->send_email_to_player($email, $subject, $body);
+    }
+}

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -22,6 +22,7 @@ if (isset($_POST['backstory_changes'])) {
 		<br />
 		The Spelleider Team<br />
 		Eos: Frontier";
+		$apiPut->set_reminder_time($_POST['id']);
 		} 
 			else {
 				$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
@@ -64,6 +65,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
+		$apiPut->set_reminder_time($_POST['id']);
 	} 
 	else {
 		if (isset($_POST['backstory-content']) && $_POST['type'] == 'backstory') {

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -73,7 +73,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		}
 
 		if (isset($_POST['method']) && $_POST['method'] == 'sl_backend') {
-			$status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
+			$status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
 		}
         //Concept approved by SL - Notify player to work on their backstory 
 		else {

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -20,13 +20,12 @@ if (isset($_POST['backstory_changes'])) {
 		<br />
 		The Spelleider Team<br />
 		Eos: Frontier";
-		} 
-			else {
-				$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
-				$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
-				$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
-				$subject = 'Backstory changes requested';
-				$body = "Dear player,
+		} else {
+			$content['content'] = str_replace("'", '&#39;', $_POST['backstory_changes']);
+			$return = $text->save_backstory_changes($_POST['id'], $content, $jid);
+			$saved = $status->update_status($_POST['id'], $_POST['status'], 'backstory', $jid);
+			$subject = 'Backstory changes requested';
+			$body = "Dear player,
 				<br /><br />
 				The SL team have requested a change in your character backstory. <br />
 				Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to see the changes we've requested.
@@ -36,7 +35,7 @@ if (isset($_POST['backstory_changes'])) {
 				<br />
 				The Spelleider Team<br />
 				Eos: Frontier";
-			}
+		}
 		$mail->send_email_to_player($email, $subject, $body);
 
 	}
@@ -48,8 +47,8 @@ if (isset($_POST['backstory_changes'])) {
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'approved')) {
 	$email = $api->get_user_email($_POST['id']);
-    //Reminder that concept is approved, backstory is not started
-    if ($_POST['type'] == 'concept_approved_remind') {
+	//Reminder that concept is approved, backstory is not started
+	if ($_POST['type'] == 'concept_approved_remind') {
 		$mail = new Send_Email();
 		$subject = 'REMINDER: Character Concept approved - please submit backstory.';
 		$body = "Dear player,
@@ -62,8 +61,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-	} 
-	else {
+	} else {
 		if (isset($_POST['backstory-content']) && $_POST['type'] == 'backstory') {
 			$id = $_POST['id'];
 			$content['content'] = str_replace("'", '&#39;', $_POST['backstory-content']);
@@ -73,7 +71,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 		if (isset($_POST['method']) && $_POST['method'] == 'sl_backend') {
 			$status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
 		}
-        //Concept approved by SL - Notify player to work on their backstory 
+		//Concept approved by SL - Notify player to work on their backstory 
 		else {
 			$mail = new Send_Email();
 			if ($_POST['type'] == 'concept') {
@@ -93,8 +91,7 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'ap
 						<br />
 						The Spelleider Team<br />
 						Eos: Frontier";
-				} 
-				else {
+				} else {
 					$body = "Dear player,
 					<br /><br />
 					The SL team have approved your character concept. <br />
@@ -146,8 +143,7 @@ if (isset($_POST['concept_changes'])) {
 			The Spelleider Team<br />
 			Eos: Frontier";
 			$mail->send_email_to_player($email, $subject, $body);
-		} 
-		else {
+		} else {
 			$content['content'] = str_replace("'", '&#39;', $_POST['concept_changes']);
 			$return = $text->save_concept_changes($_POST['id'], $content, $jid);
 			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);
@@ -175,8 +171,8 @@ if (isset($_POST['concept_changes'])) {
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'being_edited')) {
 	$email = $api->get_user_email($_POST['id']);
-    //Reminder that concept is approved, backstory is not started
-    if ($_POST['type'] == 'concept_not_submitted_remind') {
+	//Reminder that concept is approved, backstory is not started
+	if ($_POST['type'] == 'concept_not_submitted_remind') {
 		$mail = new Send_Email();
 		$subject = 'REMINDER: Character Concept not yet submitted.';
 		$body = "Dear player,
@@ -189,9 +185,8 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'be
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-	} 
-    elseif ($_POST['type'] == 'backstory_not_submitted_remind') {
-        $mail = new Send_Email();
+	} elseif ($_POST['type'] == 'backstory_not_submitted_remind') {
+		$mail = new Send_Email();
 		$subject = 'REMINDER: Backstory not yet submitted.';
 		$body = "Dear player,
 		<br /><br />
@@ -203,22 +198,22 @@ if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'be
 		The Spelleider Team<br />
 		Eos: Frontier";
 		$mail->send_email_to_player($email, $subject, $body);
-    }
+	}
 }
 
 if (isset($_POST['type']) && isset($_POST['status']) && ($_POST['status'] == 'requested')) {
-    if ($_POST['type'] == 'concept_not_started_remind') {
-        $mail = new Send_Email();
-        $subject = 'REMINDER: Concept not yet submitted.';
-        $body = "Dear player,
+	if ($_POST['type'] == 'concept_not_started_remind') {
+		$mail = new Send_Email();
+		$subject = 'REMINDER: Concept not yet submitted.';
+		$body = "Dear player,
         <br /><br />
-        The SL team would like to remind you that we still need a Character Concept submitted.. <br />
+        The SL team would like to remind you that we still need a Character Concept submitted. <br />
         Please proceed to <a href='https://www.eosfrontier.space/eos_backstory/'>the backstory editor</a> to submit your Character Concept for approval.
         <br /><br />
         Kind regards,
         <br />
         The Spelleider Team<br />
         Eos: Frontier";
-        $mail->send_email_to_player($email, $subject, $body);
-    }
+		$mail->send_email_to_player($email, $subject, $body);
+	}
 }

--- a/admin/partials/email_messages.php
+++ b/admin/partials/email_messages.php
@@ -152,7 +152,7 @@ if (isset($_POST['concept_changes'])) {
 			$mail->send_email_to_player($email, $subject, $body);
 			$apiPut->set_reminder_time($_POST['id']);
 		} 
-		elseif ($_POST['type'] == 'changes_requested') {
+		elseif ($_POST['type'] == 'concept' && $_POST['status'] == 'changes_requested') {
 			$content['content'] = str_replace("'", '&#39;', $_POST['concept_changes']);
 			$return = $text->save_concept_changes($_POST['id'], $content, $jid);
 			$saved = $status->update_status($_POST['id'], $_POST['status'], 'concept', $jid);

--- a/admin/partials/submit_existing.php
+++ b/admin/partials/submit_existing.php
@@ -11,9 +11,9 @@
 			}
 			if (isset($_POST['character'])) {
 				$selected = $_POST['character'] == $char['characterID'] ? 'selected' : '';
-				echo '<option class="overview-row factionselector fct_any' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '" ' . $selected . '  >' . $char['character_name'] . '</option>';
+				echo '<option class="factionblurb factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '" ' . $selected . '  >' . $char['character_name'] . '</option>';
 			} else {
-				echo '<option class="overview-row factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '"  >' . $char['character_name'] . '</option>';
+				echo '<option class="factionblurb factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '"  >' . $char['character_name'] . '</option>';
 			}
 		}
 		?>
@@ -33,12 +33,12 @@ if (isset($_POST['character'])) {
 		<div id="backstory-editor" style="display: block;">
 			<form method="post">
 				<textarea name="backstory-content" id="existing-backstory-textarea">
-						<?php
-						if (isset($backstory->content)) {
-							echo $backstory->content;
-						}
-						?>
-					</textarea>
+							<?php
+							if (isset($backstory->content)) {
+								echo $backstory->content;
+							}
+							?>
+						</textarea>
 				<input type="hidden" name="type" value="backstory" />
 				<input type="hidden" name="status" value="approved" />
 				<input type="hidden" name="method" value="sl_backend" />

--- a/admin/partials/submit_existing.php
+++ b/admin/partials/submit_existing.php
@@ -11,9 +11,9 @@
 			}
 			if (isset($_POST['character'])) {
 				$selected = $_POST['character'] == $char['characterID'] ? 'selected' : '';
-				echo '<option class="factionblurb factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '" ' . $selected . '  >' . $char['character_name'] . '</option>';
+				echo '<option class="overview-row factionselector fct_any' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '" ' . $selected . '  >' . $char['character_name'] . '</option>';
 			} else {
-				echo '<option class="factionblurb factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '"  >' . $char['character_name'] . '</option>';
+				echo '<option class="overview-row factionselector fct_' . $char['faction'] . '" style="display: none;" value="' . $char['characterID'] . '"  >' . $char['character_name'] . '</option>';
 			}
 		}
 		?>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -74,9 +74,11 @@ h1,
 h2,
 h3,
 h4,
-h5 {
+h5,
+h6 {
     font-weight: 400;
     text-transform: uppercase;
+    margin-left: 10px;
 }
 
 h3 span {
@@ -272,6 +274,14 @@ main {
 
 .overview-block h4.active::after {
     content: "▲";
+}
+
+h5.mouse_hover.active::after {
+    content: "▲";
+}
+
+h5.mouse_hover::after {
+    content: "▼";
 }
 
 .status-block h3::after {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -231,6 +231,9 @@ main {
 .admin_concept_edit {
     display: none;
 }
+/* .admin_concept_names {
+    display: none;
+} */
 
 .admin_concept_comment {
     display: none;
@@ -268,6 +271,17 @@ main {
 }
 
 .overview-block h4.active::after {
+    content: "▲";
+}
+
+
+.status-block h3::after {
+    content: "▼";
+    font-size: 14px;
+    margin-left: 12px;
+}
+
+.status-block h3.active::after {
     content: "▲";
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -274,7 +274,6 @@ main {
     content: "▲";
 }
 
-
 .status-block h3::after {
     content: "▼";
     font-size: 14px;

--- a/includes/Api/Put.php
+++ b/includes/Api/Put.php
@@ -159,4 +159,20 @@ class Put
 
 		return $response;
 	}
+	public function set_reminder_time($id)
+	{
+
+		$headers = [
+			'type: reminder',
+			"token: $this->token",
+			"char_id: $id",
+		];
+
+		$location = 'v2/chars_player/backstory/reminder_sent/';
+
+		$response = $this->get($headers, $location);
+
+		return $response;
+	}
 }
+

--- a/partials/backstory.php
+++ b/partials/backstory.php
@@ -1,17 +1,17 @@
 <hr />
-<h2>Backstory -  <?php echo $character->get_character_name( $id ); ?></h2>
+<h2>Backstory - <?php echo $character->get_character_name($id); ?></h2>
 <h3><span>Status:</span>
 	<?php echo $backstory->status_description; ?>
 </h3>
 <div class="text">
 	<div class="text-container">
-	<h4>Backstory:</h4>
-	<div class="content-block">
+		<h4>Backstory:</h4>
+		<div class="content-block">
 			<?php echo $backstory->content; ?>
 		</div>
 	</div>
 	<?php
-	if ( $backstory->backstory_changes && $backstory->status_name !== 'approved' ) {
+	if ($backstory->backstory_changes && $backstory->status_name !== 'approved') {
 		?>
 		<h4>Requested changes</h4>
 		<?php
@@ -25,22 +25,23 @@
 		'changes_requested',
 	];
 
-	if ( in_array( $backstory->status_name, $edit_status, true ) ) {
+	if (in_array($backstory->status_name, $edit_status, true)) {
 		?>
 		<button class="edit-backstory-button button button--secondary">
 			Edit backstory
 		</button>
 		<?php
-	};
+	}
+	;
 	?>
-	<?php if ( ( $backstory->status_name === 'being_edited' || $backstory->status_name === 'changes_requested' ) && ! empty( $backstory->content ) ) { ?>
+	<?php if (($backstory->status_name === 'being_edited' || $backstory->status_name === 'changes_requested') && !empty($backstory->content)) { ?>
 		<form method="POST">
 			<input type="hidden" name="type" value="backstory" />
 			<input type="hidden" name="status" value="awaiting_review" />
 			<button class="submit-backstory button button--primary">Submit backstory</button>
 		</form>
 	<?php } ?>
-	<?php if ( $backstory->status_name === 'awaiting_review' ) { ?>
+	<?php if ($backstory->status_name === 'awaiting_review') { ?>
 		<form method="POST">
 			<input type="hidden" name="type" value="backstory" />
 			<input type="hidden" name="status" value="being_edited" />
@@ -54,7 +55,9 @@
 			<?php echo $backstory->content; ?>
 		</textarea>
 		<input type="hidden" name="type" value="backstory" />
-		<input type="hidden" name="status" value="being_edited" />
-		<button class="button button--primary">Save Draft</button>
+		<button class="button button--secondary" name="status" type="submit" value="being_edited">Save
+			Draft</button>
+		<button class="button button--primary" name="status" type="submit" value="awaiting_review">Submit to SLs for
+			Approval</button>
 	</form>
 </div>

--- a/partials/concept.php
+++ b/partials/concept.php
@@ -64,11 +64,13 @@
 		<div id="concept-editor">
 			<form method="post">
 				<textarea name="concept-content" id="concept-textarea">
-							<?php echo $concept->content; ?>
-						</textarea>
+								<?php echo $concept->content; ?>
+							</textarea>
 				<input type="hidden" name="type" value="concept" />
-				<input type="hidden" name="status" value="being_edited" />
-				<button class="button button--primary">Save Draft</button>
+				<button class="button button--secondary" name="status" type="submit" value="being_edited">Save
+					Draft</button>
+				<button class="button button--primary" name="status" type="submit" value="awaiting_review">Submit to SLs for
+					Approval</button>
 			</form>
 		</div>
 	<?php } ?>

--- a/partials/new_concept.php
+++ b/partials/new_concept.php
@@ -5,8 +5,8 @@
 		<form method="post">
 			<textarea name="concept-content" id="concept-textarea_new"></textarea>
 			<input type="hidden" name="type" value="concept" />
-			<input type="hidden" name="status" value="being_edited" />
-			<button class="button button--primary">Save Draft</button>
+			<button class="button button--secondary" name="status" type="submit" value="being_edited">Save Draft</button>
+			<button class="button button--primary" name="status" type="submit" value="awaiting_review">Submit to SLs for Approval</button>
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Closes #23 

# Added
## Admin
* Concept requested section added on concept tab
* Send reminder button for each status that is waiting for player, with accompanying text to tell you when the last time we pestered the player was
## Player
* Players previoussly had to click Save Draft and then click Submit. -- They now have two options. Save Draft, Submit to SLs for approval

## Changed
## Admin
* All sections are now collapsed by default

